### PR TITLE
chore: add .nvmrc (lts/boron)

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/boron


### PR DESCRIPTION
Dodaje `.nvmrc` z `lts/boron`.

dopasowane do engines '6.7.0' (Node 6).

Dzięki temu `nvm use` automatycznie dobiera właściwą linię Node dla repo.