### PR TITLE
Use https for license link

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,4 +133,4 @@ $ yarn run start
 
 ## License
 
-[The MIT License](http://piecioshka.mit-license.org) @ 2026
+[The MIT License](https://piecioshka.mit-license.org) @ 2026


### PR DESCRIPTION
Switches the README license link from http:// to https://piecioshka.mit-license.org.